### PR TITLE
Add Tor Support

### DIFF
--- a/cc.retroshare.retroshare-gui.yaml
+++ b/cc.retroshare.retroshare-gui.yaml
@@ -74,6 +74,22 @@ modules:
     url: https://ftp.gnu.org/gnu/libmicrohttpd/libmicrohttpd-0.9.63.tar.gz
     sha256: 37c36f1be177f0e37ef181a645cd3baac1000bd322a01c2eff70f3cc8c91749c
 
+# tor dep
+- name: libevent
+  buildsystem: autotools
+  sources:
+  - type: archive
+    url: https://github.com/libevent/libevent/releases/download/release-2.1.11-stable/libevent-2.1.11-stable.tar.gz
+    sha256: a65bac6202ea8c5609fd5c7e480e6d25de467ea1917c08290c521752f147283d
+
+# retroshare dep
+- name: tor
+  buildsystem: autotools
+  sources:
+  - type: archive
+    url: https://dist.torproject.org/tor-0.4.2.7.tar.gz
+    sha256: 06a1d835ddf382f6bca40a62e8fb40b71b2f73d56f0d53523c8bd5caf9b3026d
+
 - name: retroshare-gui
   buildsystem: qmake
   config-opts:


### PR DESCRIPTION
Hi, this PR adds Tor to the Flatpak so you can now use the "Hidden Node (over Tor)" option out of the box.

Without Tor inside the sandbox and after selecting the "Hidden Node (over Tor)" you get the following error without this PR:

![image](https://user-images.githubusercontent.com/1387224/78241923-78b7da80-74e1-11ea-9f6a-1d42ebca8b5a.png)

I think you can get it working by manually setting up up Tor on the host (I haven't tried), but I think having it "just work" without any configuration on the users part is the better option.